### PR TITLE
Update socar-build-and-push-image.yaml

### DIFF
--- a/.github/workflows/socar-build-and-push-image.yaml
+++ b/.github/workflows/socar-build-and-push-image.yaml
@@ -5,7 +5,7 @@ on:
       airflow-version:
         description: '에어플로우 버전'
         required: true
-        default: '2.3.2'
+        default: '2.5.3'
       python-version:
         description: '파이썬 버전'
         required: true
@@ -13,7 +13,7 @@ on:
       extra-pip-packages:
         description: '추가 pip 패키지'
         required: false
-        default: 'apache-airflow[sentry],datadog,gspread,acryl-datahub-airflow-plugin'
+        default: 'apache-airflow[sentry],datadog,gspread,acryl-datahub-airflow-plugin,xmltodict,apache-airflow-providers-cncf-kubernetes,pytest'
       extra-git-repo:
         description: '추가 git repo python 패키지'
         required: false


### PR DESCRIPTION
default airflow 버전을 2.5.3으로 변경
default extra pip packages 추가

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
